### PR TITLE
add gentoo package for libatomic

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2441,7 +2441,7 @@ libatomic:
   arch: [gcc-libs]
   debian: [libatomic1]
   fedora: [libatomic]
-  gentoo: [dev-libs/libatomic_ops]
+  gentoo: [sys-devel/gcc]
   nixos: []
   openembedded: [gcc-runtime@openembedded-core]
   rhel: [libatomic]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2441,6 +2441,7 @@ libatomic:
   arch: [gcc-libs]
   debian: [libatomic1]
   fedora: [libatomic]
+  gentoo: [dev-libs/libatomic_ops]
   nixos: []
   openembedded: [gcc-runtime@openembedded-core]
   rhel: [libatomic]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libatomic

## Package Upstream Source:

https://gcc.gnu.org/

## Purpose of using this:

In order to compile ros-galactic for gentoo with superflore, we need to add the gentoo package for libatomic.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - ALREADY AVAILABLE
- Ubuntu: https://packages.ubuntu.com/
   - ALREADY AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/libatomic_ops

Most of the packages have already been added in #29030
Related to https://github.com/ros-infrastructure/superflore/issues/292